### PR TITLE
fix: Use existing Material Symbols Outlined for toast icons

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,4 +16,5 @@
 
     <app-footer />
   </div>
+  <app-toast></app-toast>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { NavComponent } from './shared/feature/nav/nav.component';
 import { NotificationsComponent } from './shared/ui/notifications/notifications.component';
 import { SearchComponent } from './shared/feature/search/search.component';
 import { PanelComponent } from './shared/ui/panel/panel.component';
+import { ToastComponent } from './shared/ui/toast/toast.component';
 import { DnaBackgroundComponent } from "./shared/ui/dna-background/dna-background.component";
 import { DeviceCapabilityService } from './shared/utils/device-capability-check.service';
 import { SsrPlatformService } from './shared/utils/ssr/ssr-platform.service';
@@ -28,7 +29,8 @@ import { SsrPlatformService } from './shared/utils/ssr/ssr-platform.service';
     NavComponent,
     SearchComponent,
     NotificationsComponent,
-    DnaBackgroundComponent
+    DnaBackgroundComponent,
+    ToastComponent
 ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'

--- a/src/app/auth/data-access/auth.store.ts
+++ b/src/app/auth/data-access/auth.store.ts
@@ -5,6 +5,7 @@ import { AuthResponse, RegisterPayload } from '../utils/auth.model';
 import { AuthService } from './auth.service';
 import { UserService } from '../../users/data-access/user.service';
 import { CookieService } from '../../shared/data-access/cookie.service';
+import { ToastService } from '../../shared/data-access/toast.service';
 import { SsrPlatformService } from '../../shared/utils/ssr/ssr-platform.service';
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
@@ -19,6 +20,7 @@ export class AuthStore {
   private readonly cookieService = inject(CookieService);
   private readonly platform = inject(SsrPlatformService);
   private readonly router = inject(Router);
+  private readonly toastService = inject(ToastService);
 
   readonly user$$ = signal<User | null>(null);
   readonly token$$ = signal<string | null>(null);
@@ -218,6 +220,7 @@ export class AuthStore {
         });
         this.loading$$.set(false);
         this.error$$.set(null);
+        this.toastService.success('Login successful!');
         this.router.navigate(['/']);
       },
       error: (error: any) => {

--- a/src/app/shared/data-access/toast.service.spec.ts
+++ b/src/app/shared/data-access/toast.service.spec.ts
@@ -1,0 +1,219 @@
+import { TestBed } from '@angular/core/testing';
+import { ToastService, Toast } from './toast.service';
+import { v4 as uuid } from 'uuid';
+
+// Mock the uuid library
+jest.mock('uuid');
+
+describe('ToastService', () => {
+  let service: ToastService;
+  let mockUuid: jest.MockedFunction<typeof uuid>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ToastService],
+    });
+    service = TestBed.inject(ToastService);
+    mockUuid = uuid as jest.MockedFunction<typeof uuid>;
+
+    // Reset toasts before each test
+    service.clearAll();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('Adding Toasts', () => {
+    it('should add a success toast with correct properties', () => {
+      mockUuid.mockReturnValue('test-id-1');
+      service.success('Success message', 1000, false);
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0]).toEqual({
+        id: 'test-id-1',
+        message: 'Success message',
+        type: 'success',
+        sticky: false,
+        timeout: 1000,
+      });
+    });
+
+    it('should add an error toast with correct properties', () => {
+      mockUuid.mockReturnValue('test-id-2');
+      service.error('Error message', 2000, true);
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0]).toEqual({
+        id: 'test-id-2',
+        message: 'Error message',
+        type: 'error',
+        sticky: true,
+        timeout: 2000,
+      });
+    });
+
+    it('should add a warning toast with default sticky and custom timeout', () => {
+      mockUuid.mockReturnValue('test-id-3');
+      service.warning('Warning message', 1500);
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0]).toEqual({
+        id: 'test-id-3',
+        message: 'Warning message',
+        type: 'warning',
+        sticky: false,
+        timeout: 1500,
+      });
+    });
+
+    it('should add an info toast with default timeout and sticky', () => {
+      mockUuid.mockReturnValue('test-id-4');
+      service.info('Info message');
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0]).toEqual(
+        expect.objectContaining({
+          id: 'test-id-4',
+          message: 'Info message',
+          type: 'info',
+          sticky: false,
+          // Default timeout for info is 3000
+          timeout: 3000,
+        })
+      );
+    });
+
+    it('should generate unique IDs for multiple toasts', () => {
+      mockUuid.mockReturnValueOnce('id-1').mockReturnValueOnce('id-2');
+      service.success('First toast');
+      service.error('Second toast');
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(2);
+      expect(toasts[0].id).toBe('id-1');
+      expect(toasts[1].id).toBe('id-2');
+    });
+
+    it('should use default timeout if not provided (success)', () => {
+      service.success('Success message');
+      const toasts = service.toasts$();
+      expect(toasts[0].timeout).toBe(3000); // Default for success
+    });
+
+    it('should use default timeout if not provided (error)', () => {
+      service.error('Error message');
+      const toasts = service.toasts$();
+      expect(toasts[0].timeout).toBe(5000); // Default for error
+    });
+
+    it('should use default timeout if not provided (warning)', () => {
+      service.warning('Warning message');
+      const toasts = service.toasts$();
+      expect(toasts[0].timeout).toBe(4000); // Default for warning
+    });
+
+    it('should use default timeout if not provided (info)', () => {
+      service.info('Info message');
+      const toasts = service.toasts$();
+      expect(toasts[0].timeout).toBe(3000); // Default for info
+    });
+
+
+    it('should correctly set sticky property', () => {
+      service.success('Sticky toast', 5000, true);
+      service.error('Non-sticky toast', 5000, false);
+      const toasts = service.toasts$();
+      expect(toasts[0].sticky).toBe(true);
+      expect(toasts[1].sticky).toBe(false);
+    });
+  });
+
+  describe('Dismissing Toasts', () => {
+    beforeEach(() => {
+      mockUuid.mockReturnValueOnce('id-dismiss-1').mockReturnValueOnce('id-dismiss-2');
+      service.info('Toast 1');
+      service.info('Toast 2');
+    });
+
+    it('should dismiss the correct toast by ID', () => {
+      let toasts = service.toasts$();
+      expect(toasts.length).toBe(2);
+      expect(toasts.find(t => t.id === 'id-dismiss-1')).toBeDefined();
+
+      service.dismiss('id-dismiss-1');
+      toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts.find(t => t.id === 'id-dismiss-1')).toBeUndefined();
+      expect(toasts[0].id).toBe('id-dismiss-2');
+    });
+
+    it('should do nothing if ID to dismiss is not found', () => {
+      let toasts = service.toasts$();
+      expect(toasts.length).toBe(2);
+
+      service.dismiss('non-existent-id');
+      toasts = service.toasts$();
+      expect(toasts.length).toBe(2); // No change
+    });
+  });
+
+  describe('Clearing Toasts', () => {
+    it('should remove all toasts when clearAll is called', () => {
+      mockUuid.mockReturnValueOnce('id-clear-1').mockReturnValueOnce('id-clear-2');
+      service.success('Toast A');
+      service.error('Toast B');
+      let toasts = service.toasts$();
+      expect(toasts.length).toBe(2);
+
+      service.clearAll();
+      toasts = service.toasts$();
+      expect(toasts.length).toBe(0);
+    });
+
+    it('should handle clearAll when there are no toasts', () => {
+      let toasts = service.toasts$();
+      expect(toasts.length).toBe(0);
+
+      service.clearAll();
+      toasts = service.toasts$();
+      expect(toasts.length).toBe(0);
+    });
+  });
+
+  describe('Signal Behavior', () => {
+    it('toasts$ should emit updated list after adding a toast', () => {
+      mockUuid.mockReturnValue('sig-id-1');
+      service.success('Signal test');
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0].message).toBe('Signal test');
+    });
+
+    it('toasts$ should emit updated list after dismissing a toast', () => {
+      mockUuid.mockReturnValueOnce('sig-id-2a').mockReturnValueOnce('sig-id-2b');
+      service.info('Toast X');
+      service.info('Toast Y');
+
+      service.dismiss('sig-id-2a');
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0].id).toBe('sig-id-2b');
+    });
+
+    it('toasts$ should emit an empty list after clearAll', () => {
+      mockUuid.mockReturnValue('sig-id-3');
+      service.warning('Another toast');
+      service.clearAll();
+      const toasts = service.toasts$();
+      expect(toasts.length).toBe(0);
+    });
+  });
+
+  // Note: Testing the actual setTimeout behavior for auto-dismissal
+  // is more complex and often involves fakeAsync, tick, and potentially
+  // spying on window.setTimeout. For this service, the primary responsibility
+  // is managing the toasts array and signal. The auto-dismissal initiator
+  // is tested by checking if the timeout property is set.
+  // The component tests would be a better place to verify if the
+  // dismiss call actually happens after a timeout.
+});

--- a/src/app/shared/data-access/toast.service.ts
+++ b/src/app/shared/data-access/toast.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, signal } from '@angular/core';
+import { v4 as uuid } from 'uuid';
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: 'success' | 'error' | 'warning' | 'info';
+  sticky: boolean;
+  timeout?: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ToastService {
+  private toasts$$ = signal<Toast[]>([]);
+  public readonly toasts$ = this.toasts$$.asReadonly();
+  private activeTimeouts: Map<string, number> = new Map();
+
+  private push(
+    message: string,
+    type: 'success' | 'error' | 'warning' | 'info',
+    timeout?: number,
+    sticky: boolean = false
+  ): void {
+    const newToast: Toast = {
+      id: uuid(),
+      message,
+      type,
+      sticky,
+      timeout,
+    };
+    this.toasts$$.update((toasts) => [...toasts, newToast]);
+
+    if (!sticky && timeout) {
+      const timeoutId = window.setTimeout(() => {
+        this.dismiss(newToast.id);
+        // No need to remove from activeTimeouts here, dismiss() will handle it
+      }, timeout);
+      this.activeTimeouts.set(newToast.id, timeoutId);
+    }
+  }
+
+  success(message: string, timeout: number = 3000, sticky: boolean = false): void {
+    this.push(message, 'success', timeout, sticky);
+  }
+
+  error(message: string, timeout: number = 5000, sticky: boolean = false): void {
+    this.push(message, 'error', timeout, sticky);
+  }
+
+  warning(message: string, timeout: number = 4000, sticky: boolean = false): void {
+    this.push(message, 'warning', timeout, sticky);
+  }
+
+  info(message: string, timeout: number = 3000, sticky: boolean = false): void {
+    this.push(message, 'info', timeout, sticky);
+  }
+
+  dismiss(id: string): void {
+    if (this.activeTimeouts.has(id)) {
+      clearTimeout(this.activeTimeouts.get(id));
+      this.activeTimeouts.delete(id);
+    }
+    this.toasts$$.update((toasts) => toasts.filter((toast) => toast.id !== id));
+  }
+
+  clearAll(): void {
+    this.activeTimeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+    this.activeTimeouts.clear();
+    this.toasts$$.set([]);
+  }
+}

--- a/src/app/shared/ui/toast/toast.component.html
+++ b/src/app/shared/ui/toast/toast.component.html
@@ -1,0 +1,17 @@
+<div class="toast-container">
+  <div
+    *ngFor="let toast of toasts()"
+    class="toast toast--{{ toast.type }}"
+  >
+    <i class="material-symbols-outlined toast-icon" [ngSwitch]="toast.type">
+      <ng-container *ngSwitchCase="'success'">check_circle</ng-container>
+      <ng-container *ngSwitchCase="'error'">error</ng-container>
+      <ng-container *ngSwitchCase="'warning'">warning</ng-container>
+      <ng-container *ngSwitchCase="'info'">info</ng-container>
+    </i>
+    <span class="toast-message">{{ toast.message }}</span>
+    <button class="toast-dismiss-button" (click)="dismiss(toast.id)">
+      &times;
+    </button>
+  </div>
+</div>

--- a/src/app/shared/ui/toast/toast.component.scss
+++ b/src/app/shared/ui/toast/toast.component.scss
@@ -1,0 +1,89 @@
+@import 'styles/abstracts/toast-colors';
+
+:host {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.toast-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.toast {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  color: var(--color-white); // Assuming white text for good contrast
+  min-width: 250px;
+  max-width: 400px;
+  word-break: break-word;
+  animation: toastEnter 0.3s ease-out;
+  // Default text color, can be overridden by specific types
+  color: $toast-info-text; // Defaulting to info text color, can be any base
+
+  &--success {
+    background-color: $toast-success-bg;
+    color: $toast-success-text;
+  }
+
+  &--error {
+    background-color: $toast-error-bg;
+    color: $toast-error-text;
+  }
+
+  &--warning {
+    background-color: $toast-warning-bg;
+    color: $toast-warning-text;
+  }
+
+  &--info {
+    background-color: $toast-info-bg;
+    color: $toast-info-text; // Explicitly set, though it's the default above
+  }
+}
+
+.toast-icon {
+  margin-right: 8px;
+  // Optional: Adjust icon size if needed, e.g., font-size: 20px;
+  // Material Icons typically inherit color, so specific color styling might not be needed
+  // unless a different color from the toast text is desired.
+}
+
+.toast-message {
+  flex-grow: 1;
+}
+
+.toast-dismiss-button {
+  background: transparent;
+  border: none;
+  color: inherit; // Inherits color from parent (.toast)
+  font-size: 20px;
+  line-height: 1;
+  margin-left: 10px;
+  padding: 0 5px;
+  cursor: pointer;
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+@keyframes toastEnter {
+  from {
+    opacity: 0;
+    transform: translateX(100%); // Start off-screen to the right
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0); // Slide to original position
+  }
+}

--- a/src/app/shared/ui/toast/toast.component.ts
+++ b/src/app/shared/ui/toast/toast.component.ts
@@ -1,0 +1,25 @@
+import { Component, inject } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { ToastService, Toast } from '../../data-access/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [NgFor],
+  templateUrl: './toast.component.html',
+  styleUrls: ['./toast.component.scss'],
+})
+export class ToastComponent {
+  private toastService = inject(ToastService);
+  public toasts = this.toastService.toasts$; // Renamed from toasts$ to toasts
+
+  // OnInit, OnDestroy, and timeouts map are removed.
+  // The ToastService's push method already handles setTimeout for auto-dismissal.
+
+  dismiss(id: string): void {
+    this.toastService.dismiss(id);
+    // No need to manage timeouts here anymore as the service handles it.
+    // If a toast is manually dismissed, its timeout in the service will eventually
+    // try to dismiss a non-existent toast, which is harmless.
+  }
+}

--- a/src/styles/abstracts/_toast-colors.scss
+++ b/src/styles/abstracts/_toast-colors.scss
@@ -1,0 +1,15 @@
+// Toast Color Variables
+// These variables utilize existing CSS theme variables to provide
+// a specific abstraction layer for toast component styling.
+
+$toast-success-bg: var(--color-success-500);
+$toast-success-text: var(--color-white);
+
+$toast-error-bg: var(--color-error-500);
+$toast-error-text: var(--color-white);
+
+$toast-warning-bg: var(--color-warning-500);
+$toast-warning-text: var(--color-black); // Using black for better contrast on yellow
+
+$toast-info-bg: var(--color-info-500);
+$toast-info-text: var(--color-white);


### PR DESCRIPTION
Updates the ToastComponent to use the 'Material Symbols Outlined' font already present in your project, instead of the previously added 'Material Icons'.

- Removed the redundant 'Material Icons' font link from index.html.
- ToastComponent now applies the 'material-symbols-outlined' class for icons.
- Verified that the existing font loading mechanism for 'Material Symbols Outlined' is appropriate and does not require further optimization at this time due to its broad usage across the application.